### PR TITLE
Php 8.1 changes

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -44,7 +44,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: true
-          tags: ${{ secrets.DOCKERHUB_ACCOUNT }}/php:8-fpm
+          tags: ${{ secrets.DOCKERHUB_ACCOUNT }}/php:8.0-fpm
       - name: PHP 8 Apache
         uses: docker/build-push-action@v2
         with:
@@ -55,18 +55,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: true
-          tags: ${{ secrets.DOCKERHUB_ACCOUNT }}/php:8-apache
-#      - name: PHP 8 ZTS
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: ./
-#          file: ./Dockerfile-8-zts
-#          builder: ${{ steps.buildx.outputs.name }}
-#          platforms: linux/amd64,linux/arm64/v8
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
-#          push: true
-#          tags: ${{ secrets.DOCKERHUB_ACCOUNT }}/php:8-zts
+          tags: ${{ secrets.DOCKERHUB_ACCOUNT }}/php:8.0-apache
       - name: PHP 8 CLI
         uses: docker/build-push-action@v2
         with:
@@ -77,50 +66,61 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: true
-          tags: ${{ secrets.DOCKERHUB_ACCOUNT }}/php:8-cli
-
-#  php-8-buster:
-#    # The type of runner that the job will run on
-#    runs-on: ubuntu-latest
-#    timeout-minutes: 720
-#    # Steps represent a sequence of tasks that will be executed as part of the job
-#    steps:
-#      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-#      - name: Checkout Repo
-#        uses: actions/checkout@v2
-#      - name: Login to Dockerhub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-#      - name: Set up QEMU
-#        uses: docker/setup-qemu-action@v1
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v1
-#      - name: PHP 8 FPM Buster
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: ./
-#          file: ./Dockerfile-8-fpm
-#          builder: ${{ steps.buildx.outputs.name }}
-#          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
-#          push: true
-#          build-args: OS=buster
-#          tags: zmtsys/php:8-fpm-buster
-#      - name: PHP 8 Apache Buster
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: ./
-#          file: ./Dockerfile-8-apache
-#          builder: ${{ steps.buildx.outputs.name }}
-#          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
-#          push: true
-#          build-args: OS=buster
-#          tags: zmtsys/php:8-apache-buster
+          tags: ${{ secrets.DOCKERHUB_ACCOUNT }}/php:8.0-cli
+  
+  php-81:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    timeout-minutes: 720
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Login to Dockerhub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: PHP 8.1 FPM
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile-8.1-fpm
+          builder: ${{ steps.buildx.outputs.name }}
+          platforms: linux/amd64,linux/arm64/v8
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: ${{ secrets.DOCKERHUB_ACCOUNT }}/php:8.1-fpm
+      - name: PHP 8.1 Apache
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile-8.1-apache
+          builder: ${{ steps.buildx.outputs.name }}
+          platforms: linux/amd64,linux/arm64/v8
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: ${{ secrets.DOCKERHUB_ACCOUNT }}/php:8.1-apache
+      - name: PHP 8.1 CLI
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile-8.1-cli
+          builder: ${{ steps.buildx.outputs.name }}
+          platforms: linux/amd64,linux/arm64/v8
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: ${{ secrets.DOCKERHUB_ACCOUNT }}/php:8.1-cli
 
   php-74:
     # The type of runner that the job will run on
@@ -163,49 +163,6 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKERHUB_ACCOUNT }}/php:7.4-apache
 
-#  php-74-buster:
-#    # The type of runner that the job will run on
-#    runs-on: ubuntu-latest
-#    timeout-minutes: 720
-#    # Steps represent a sequence of tasks that will be executed as part of the job
-#    steps:
-#      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-#      - name: Checkout Repo
-#        uses: actions/checkout@v2
-#      - name: Login to Dockerhub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-#      - name: Set up QEMU
-#        uses: docker/setup-qemu-action@v1
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v1
-#      - name: PHP 7.4 FPM Buster
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: ./
-#          file: ./Dockerfile-7.4-fpm
-#          builder: ${{ steps.buildx.outputs.name }}
-#          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
-#          push: true
-#          build-args: OS=buster
-#          tags: zmtsys/php:7.4-fpm-buster
-#      - name: PHP 7.4 Apache Buster
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: ./
-#          file: ./Dockerfile-7.4-apache
-#          builder: ${{ steps.buildx.outputs.name }}
-#          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
-#          push: true
-#          build-args: OS=buster
-#          tags: zmtsys/php:7.4-apache-buster
-
   php-73:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -235,34 +192,3 @@ jobs:
           cache-to: type=gha,mode=max
           push: true
           tags: ${{ secrets.DOCKERHUB_ACCOUNT }}/php:7.3-fpm
-
-#  php-73-buster:
-#    # The type of runner that the job will run on
-#    runs-on: ubuntu-latest
-#    timeout-minutes: 720
-#    # Steps represent a sequence of tasks that will be executed as part of the job
-#    steps:
-#      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-#      - name: Checkout Repo
-#        uses: actions/checkout@v2
-#      - name: Login to Dockerhub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-#      - name: Set up QEMU
-#        uses: docker/setup-qemu-action@v1
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v1
-#      - name: PHP 7.3 FPM Buster
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: ./
-#          file: ./Dockerfile-7.3-fpm
-#          builder: ${{ steps.buildx.outputs.name }}
-#          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
-#          push: true
-#          build-args: OS=buster
-#          tags: zmtsys/php:7.3-fpm-buster

--- a/Dockerfile-8-apache
+++ b/Dockerfile-8-apache
@@ -1,5 +1,5 @@
 ARG OS
-FROM php:8-apache-${OS:-bullseye}
+FROM php:8.0-apache-${OS:-bullseye}
 ARG OS
 ENV OS=${OS:-bullseye}
 LABEL description="PHP base image" \

--- a/Dockerfile-8-cli
+++ b/Dockerfile-8-cli
@@ -1,5 +1,5 @@
 ARG OS
-FROM php:8-cli-${OS:-bullseye}
+FROM php:8.0-cli-${OS:-bullseye}
 ARG OS
 ENV OS=${OS:-bullseye}
 LABEL description="PHP base image" \

--- a/Dockerfile-8-fpm
+++ b/Dockerfile-8-fpm
@@ -1,5 +1,5 @@
 ARG OS
-FROM php:8-fpm-${OS:-bullseye}
+FROM php:8.0-fpm-${OS:-bullseye}
 ARG OS
 ENV OS=${OS:-bullseye}
 LABEL description="PHP base image" \

--- a/Dockerfile-8-zts
+++ b/Dockerfile-8-zts
@@ -1,5 +1,5 @@
 ARG OS
-FROM php:8-zts-${OS:-bullseye}
+FROM php:8.0-zts-${OS:-bullseye}
 ARG OS
 ENV OS=${OS:-bullseye}
 LABEL description="PHP base image" \

--- a/Dockerfile-8.1-apache
+++ b/Dockerfile-8.1-apache
@@ -1,0 +1,176 @@
+ARG OS
+FROM php:8.1-apache-${OS:-bullseye}
+ARG OS
+ENV OS=${OS:-bullseye}
+LABEL description="PHP base image" \
+  "com.zmtsys.vendor"="Zimi Tech Inc."
+
+RUN set -eux; \
+  apt-get update \
+  && LIBAVIF=`apt-cache pkgnames libavif | head -1` \
+  && LIBMPDEC=`apt-cache pkgnames libmpdec | head -1` \
+  && apt-get install --no-install-recommends -y \
+    ca-certificates \
+    curl \
+    git \
+    imagemagick \
+    ${LIBAVIF} \
+    libcmph0 \
+    libedit2 \
+    libhashkit2 \
+    libjpeg62-turbo \
+    libmemcached11 \
+    libmemcachedutil2 \
+    ${LIBMPDEC} \
+    libmsgpackc2 \
+    libpng16-16 \
+    libsodium23 \
+    libxpm4 \
+    libzip4 \
+    netcat \
+    tzdata \
+    unzip \
+  ; \
+  apt-mark manual '.*' > /dev/null; \
+  savedAptMark="$(apt-mark showmanual)"; \
+  apt-get install -y --no-install-recommends \
+    $PHPIZE_DEPS \
+    gettext-base \
+    libargon2-dev \
+    libavif-dev \
+    libcmph-dev \
+    libcurl4-openssl-dev \
+    libedit-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libjpeg62-turbo-dev \
+    libmagick++-dev \
+    libmagickwand-dev \
+    libmemcached-dev \
+    libmpdec-dev \
+    libmsgpack-dev \
+    libpng-dev \
+    libpng++-dev \
+    libsodium-dev \
+    libssl-dev \
+    libwebp-dev \
+    libxml2-dev \
+    libxpm-dev \
+    libzip-dev \
+    libbz2-dev \
+    zlib1g-dev \
+    ${PHP_EXTRA_BUILD_DEPS:-} \
+    ; \
+  export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" \
+    ; \
+  docker-php-ext-configure gd --with-jpeg --with-xpm --with-webp --with-freetype \
+    ; \
+  docker-php-ext-install -j$(nproc) \
+    bcmath \
+    bz2 \
+    gd \
+    gettext \
+    intl \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    sockets \
+    zip \
+    ; \
+  pecl update-channels \
+    ; \
+  pecl install --onlyreqdeps --nobuild decimal; \
+    cd "$(pecl config-get temp_dir)/decimal"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild igbinary; \
+    cd "$(pecl config-get temp_dir)/igbinary"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild msgpack; \
+    cd "$(pecl config-get temp_dir)/msgpack"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild apcu; \
+    cd "$(pecl config-get temp_dir)/apcu"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild imagick; \
+    cd "$(pecl config-get temp_dir)/imagick"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild redis; \
+    cd "$(pecl config-get temp_dir)/redis"; \
+    phpize; \
+    ./configure --enable-redis-igbinary --enable-redis-json --enable-redis-msgpack; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild memcached; \
+    cd "$(pecl config-get temp_dir)/memcached"; \
+    phpize; \
+    ./configure --enable-memcached-igbinary --enable-memcached-json --enable-memcached-session --enable-memcached-sasl --enable-memcached-msgpack; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild xdebug; \
+    cd "$(pecl config-get temp_dir)/xdebug"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild ev; \
+    cd "$(pecl config-get temp_dir)/ev"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  docker-php-ext-enable \
+    apcu \
+    decimal \
+    ev \
+    igbinary \
+    imagick \
+    msgpack \
+    opcache \
+    redis \
+    ; \
+  cp /usr/bin/envsubst /usr/local/bin/envsubst; \
+  apt-mark auto '.*' > /dev/null; \
+  [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImport=false; \
+  rm -rf /tmp/* ~/.pearrc /var/lib/apt/lists/* /var/cache/*; \
+  php --version \
+  ; \
+  a2enmod \
+    buffer \
+    expires \
+    headers \
+    mime_magic \
+    remoteip \
+    rewrite \
+  ;
+
+#Security changes
+RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^expose_php\s*=\s*\(.*\)|expose_php=Off|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^\(;\)*realpath_cache_size\s*=\s*\(.*\)|realpath_cache_size=\2|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^\(;\)*realpath_cache_ttl\s*=\s*\(.*\)|realpath_cache_ttl=3600|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^\(;\)*zlib.output_compression\s*=\s*\(.*\)|zlib.output_compression=On|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^ServerSignature\(.*\)|ServerSignature Off|g" $APACHE_CONFDIR/conf-enabled/security.conf \
+  ; sed -i "s|^ServerTokens\(.*\)|ServerTokens Prod|g" $APACHE_CONFDIR/conf-enabled/security.conf \
+  ; echo "LogFormat \"\\\"%{X-Forwarded-For}i %h\\\" %l %u %t \\\"%r\\\" %>s %O \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" combined" > $APACHE_CONFDIR/conf-available/log_combined.conf \
+  ; a2enconf log_combined \
+  ;
+
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+
+WORKDIR /var/www/html

--- a/Dockerfile-8.1-cli
+++ b/Dockerfile-8.1-cli
@@ -1,0 +1,159 @@
+ARG OS
+FROM php:8.1-cli-${OS:-bullseye}
+ARG OS
+ENV OS=${OS:-bullseye}
+LABEL description="PHP base image" \
+  "com.zmtsys.vendor"="Zimi Tech Inc."
+
+RUN set -eux; \
+  apt-get update \
+  && LIBAVIF=`apt-cache pkgnames libavif | head -1` \
+  && LIBMPDEC=`apt-cache pkgnames libmpdec | head -1` \
+  && apt-get install --no-install-recommends -y \
+    ca-certificates \
+    curl \
+    git \
+    imagemagick \
+    ${LIBAVIF} \
+    libcmph0 \
+    libedit2 \
+    libhashkit2 \
+    libjpeg62-turbo \
+    libmemcached11 \
+    libmemcachedutil2 \
+    ${LIBMPDEC} \
+    libmsgpackc2 \
+    libpng16-16 \
+    libsodium23 \
+    libxpm4 \
+    libzip4 \
+    netcat \
+    tzdata \
+    unzip \
+  ; \
+  apt-mark manual '.*' > /dev/null; \
+  savedAptMark="$(apt-mark showmanual)"; \
+  apt-get install -y --no-install-recommends \
+    $PHPIZE_DEPS \
+    gettext-base \
+    libargon2-dev \
+    libavif-dev \
+    libcmph-dev \
+    libcurl4-openssl-dev \
+    libedit-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libjpeg62-turbo-dev \
+    libmagick++-dev \
+    libmagickwand-dev \
+    libmemcached-dev \
+    libmpdec-dev \
+    libmsgpack-dev \
+    libpng-dev \
+    libpng++-dev \
+    libsodium-dev \
+    libssl-dev \
+    libwebp-dev \
+    libxml2-dev \
+    libxpm-dev \
+    libzip-dev \
+    libbz2-dev \
+    zlib1g-dev \
+    ${PHP_EXTRA_BUILD_DEPS:-} \
+    ; \
+  export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" \
+    ; \
+  docker-php-ext-configure gd --with-jpeg --with-xpm --with-webp --with-freetype \
+    ; \
+  docker-php-ext-install -j$(nproc) \
+    bcmath \
+    bz2 \
+    gd \
+    gettext \
+    intl \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    sockets \
+    zip \
+    ; \
+  pecl update-channels \
+    ; \
+  pecl install --onlyreqdeps --nobuild decimal; \
+    cd "$(pecl config-get temp_dir)/decimal"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild igbinary; \
+    cd "$(pecl config-get temp_dir)/igbinary"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild msgpack; \
+    cd "$(pecl config-get temp_dir)/msgpack"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild apcu; \
+    cd "$(pecl config-get temp_dir)/apcu"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild imagick; \
+    cd "$(pecl config-get temp_dir)/imagick"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild redis; \
+    cd "$(pecl config-get temp_dir)/redis"; \
+    phpize; \
+    ./configure --enable-redis-igbinary --enable-redis-json --enable-redis-msgpack; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild memcached; \
+    cd "$(pecl config-get temp_dir)/memcached"; \
+    phpize; \
+    ./configure --enable-memcached-igbinary --enable-memcached-json --enable-memcached-session --enable-memcached-sasl --enable-memcached-msgpack; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild xdebug; \
+    cd "$(pecl config-get temp_dir)/xdebug"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild ev; \
+    cd "$(pecl config-get temp_dir)/ev"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  docker-php-ext-enable \
+    apcu \
+    ev \
+    ; \
+  cp /usr/bin/envsubst /usr/local/bin/envsubst; \
+  apt-mark auto '.*' > /dev/null; \
+  [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImport=false; \
+  rm -rf /tmp/* ~/.pearrc /var/lib/apt/lists/* /var/cache/*; \
+  php --version \
+  ;
+
+#Security changes
+RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^expose_php\s*=\s*\(.*\)|expose_php=Off|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^\(;\)*realpath_cache_size\s*=\s*\(.*\)|realpath_cache_size=\2|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^\(;\)*realpath_cache_ttl\s*=\s*\(.*\)|realpath_cache_ttl=3600|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^\(;\)*zlib.output_compression\s*=\s*\(.*\)|zlib.output_compression=On|g" $PHP_INI_DIR/php.ini \
+  ;
+
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+
+WORKDIR /var/www/html
+CMD ["php" "-a"]

--- a/Dockerfile-8.1-fpm
+++ b/Dockerfile-8.1-fpm
@@ -1,0 +1,168 @@
+ARG OS
+FROM php:8.1-fpm-${OS:-bullseye}
+ARG OS
+ENV OS=${OS:-bullseye}
+LABEL description="PHP base image" \
+  "com.zmtsys.vendor"="Zimi Tech Inc."
+
+RUN set -eux; \
+  apt-get update \
+  && LIBAVIF=`apt-cache pkgnames libavif | head -1` \
+  && LIBMPDEC=`apt-cache pkgnames libmpdec | head -1` \
+  && apt-get install --no-install-recommends -y \
+    ca-certificates \
+    curl \
+    git \
+    imagemagick \
+    ${LIBAVIF} \
+    libcmph0 \
+    libedit2 \
+    libhashkit2 \
+    libjpeg62-turbo \
+    libmemcached11 \
+    libmemcachedutil2 \
+    ${LIBMPDEC} \
+    libmsgpackc2 \
+    libpng16-16 \
+    libsodium23 \
+    libxpm4 \
+    libzip4 \
+    netcat \
+    tzdata \
+    unzip \
+  ; \
+  apt-mark manual '.*' > /dev/null; \
+  savedAptMark="$(apt-mark showmanual)"; \
+  apt-get install -y --no-install-recommends \
+    $PHPIZE_DEPS \
+    gettext-base \
+    libargon2-dev \
+    libavif-dev \
+    libcmph-dev \
+    libcurl4-openssl-dev \
+    libedit-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libjpeg62-turbo-dev \
+    libmagick++-dev \
+    libmagickwand-dev \
+    libmemcached-dev \
+    libmpdec-dev \
+    libmsgpack-dev \
+    libpng-dev \
+    libpng++-dev \
+    libsodium-dev \
+    libssl-dev \
+    libwebp-dev \
+    libxml2-dev \
+    libxpm-dev \
+    libzip-dev \
+    libbz2-dev \
+    zlib1g-dev \
+    ${PHP_EXTRA_BUILD_DEPS:-} \
+    ; \
+  export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" \
+    ; \
+  docker-php-ext-configure gd --with-jpeg --with-xpm --with-webp --with-freetype \
+    ; \
+  docker-php-ext-install -j$(nproc) \
+    bcmath \
+    bz2 \
+    gd \
+    gettext \
+    intl \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    sockets \
+    zip \
+    ; \
+  pecl update-channels \
+    ; \
+  pecl install --onlyreqdeps --nobuild decimal; \
+    cd "$(pecl config-get temp_dir)/decimal"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild igbinary; \
+    cd "$(pecl config-get temp_dir)/igbinary"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild msgpack; \
+    cd "$(pecl config-get temp_dir)/msgpack"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild apcu; \
+    cd "$(pecl config-get temp_dir)/apcu"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild imagick; \
+    cd "$(pecl config-get temp_dir)/imagick"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild redis; \
+    cd "$(pecl config-get temp_dir)/redis"; \
+    phpize; \
+    ./configure --enable-redis-igbinary --enable-redis-json --enable-redis-msgpack; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild memcached; \
+    cd "$(pecl config-get temp_dir)/memcached"; \
+    phpize; \
+    ./configure --enable-memcached-igbinary --enable-memcached-json --enable-memcached-session --enable-memcached-sasl --enable-memcached-msgpack; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild xdebug; \
+    cd "$(pecl config-get temp_dir)/xdebug"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild ev; \
+    cd "$(pecl config-get temp_dir)/ev"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  docker-php-ext-enable \
+    apcu \
+    decimal \
+    ev \
+    igbinary \
+    imagick \
+    msgpack \
+    opcache \
+    redis \
+    ; \
+  cp /usr/bin/envsubst /usr/local/bin/envsubst; \
+  apt-mark auto '.*' > /dev/null; \
+  [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImport=false; \
+  rm -rf /tmp/* ~/.pearrc /var/lib/apt/lists/* /var/cache/*; \
+  php --version \
+  ;
+
+#Security changes
+RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^expose_php\s*=\s*\(.*\)|expose_php=Off|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^\(;\)*realpath_cache_size\s*=\s*\(.*\)|realpath_cache_size=\2|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^\(;\)*realpath_cache_ttl\s*=\s*\(.*\)|realpath_cache_ttl=3600|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^\(;\)*zlib.output_compression\s*=\s*\(.*\)|zlib.output_compression=On|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s/;emergency_restart_threshold\s*=\s*.*/emergency_restart_threshold = 10/g" $PHP_INI_DIR/../php-fpm.conf \
+  ; sed -i "s/;emergency_restart_interval\s*=\s*.*/emergency_restart_interval = 1m/g" $PHP_INI_DIR/../php-fpm.conf \
+  ; sed -i "s/;process_control_timeout\s*=\s*.*/process_control_timeout = 10s/g" $PHP_INI_DIR/../php-fpm.conf \
+  ;
+
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+
+WORKDIR /var/www/html
+CMD ["php-fpm"]

--- a/Dockerfile-8.1-zts
+++ b/Dockerfile-8.1-zts
@@ -1,0 +1,159 @@
+ARG OS
+FROM php:8.1-zts-${OS:-bullseye}
+ARG OS
+ENV OS=${OS:-bullseye}
+LABEL description="PHP base image" \
+  "com.zmtsys.vendor"="Zimi Tech Inc."
+
+RUN set -eux; \
+  apt-get update \
+  && LIBAVIF=`apt-cache pkgnames libavif | head -1` \
+  && LIBMPDEC=`apt-cache pkgnames libmpdec | head -1` \
+  && apt-get install --no-install-recommends -y \
+    ca-certificates \
+    curl \
+    git \
+    imagemagick \
+    ${LIBAVIF} \
+    libcmph0 \
+    libedit2 \
+    libhashkit2 \
+    libjpeg62-turbo \
+    libmemcached11 \
+    libmemcachedutil2 \
+    ${LIBMPDEC} \
+    libmsgpackc2 \
+    libpng16-16 \
+    libsodium23 \
+    libxpm4 \
+    libzip4 \
+    netcat \
+    tzdata \
+    unzip \
+  ; \
+  apt-mark manual '.*' > /dev/null; \
+  savedAptMark="$(apt-mark showmanual)"; \
+  apt-get install -y --no-install-recommends \
+    $PHPIZE_DEPS \
+    gettext-base \
+    libargon2-dev \
+    libavif-dev \
+    libcmph-dev \
+    libcurl4-openssl-dev \
+    libedit-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libjpeg62-turbo-dev \
+    libmagick++-dev \
+    libmagickwand-dev \
+    libmemcached-dev \
+    libmpdec-dev \
+    libmsgpack-dev \
+    libpng-dev \
+    libpng++-dev \
+    libsodium-dev \
+    libssl-dev \
+    libwebp-dev \
+    libxml2-dev \
+    libxpm-dev \
+    libzip-dev \
+    libbz2-dev \
+    zlib1g-dev \
+    ${PHP_EXTRA_BUILD_DEPS:-} \
+    ; \
+  export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" \
+    ; \
+  docker-php-ext-configure gd --with-jpeg --with-xpm --with-webp --with-freetype \
+    ; \
+  docker-php-ext-install -j$(nproc) \
+    bcmath \
+    bz2 \
+    gd \
+    gettext \
+    intl \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    sockets \
+    zip \
+    ; \
+  pecl update-channels \
+    ; \
+  pecl install --onlyreqdeps --nobuild decimal; \
+    cd "$(pecl config-get temp_dir)/decimal"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild igbinary; \
+    cd "$(pecl config-get temp_dir)/igbinary"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild msgpack; \
+    cd "$(pecl config-get temp_dir)/msgpack"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild apcu; \
+    cd "$(pecl config-get temp_dir)/apcu"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild imagick; \
+    cd "$(pecl config-get temp_dir)/imagick"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild redis; \
+    cd "$(pecl config-get temp_dir)/redis"; \
+    phpize; \
+    ./configure --enable-redis-igbinary --enable-redis-json --enable-redis-msgpack; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild memcached; \
+    cd "$(pecl config-get temp_dir)/memcached"; \
+    phpize; \
+    ./configure --enable-memcached-igbinary --enable-memcached-json --enable-memcached-session --enable-memcached-sasl --enable-memcached-msgpack; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild xdebug; \
+    cd "$(pecl config-get temp_dir)/xdebug"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  pecl install --onlyreqdeps --nobuild ev; \
+    cd "$(pecl config-get temp_dir)/ev"; \
+    phpize; \
+    ./configure; \
+    make && make install; \
+    cd -; \
+  docker-php-ext-enable \
+    apcu \
+    ev \
+    ; \
+  cp /usr/bin/envsubst /usr/local/bin/envsubst; \
+  apt-mark auto '.*' > /dev/null; \
+  [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImport=false; \
+  rm -rf /tmp/* ~/.pearrc /var/lib/apt/lists/* /var/cache/*; \
+  php --version \
+  ;
+
+#Security changes
+RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^expose_php\s*=\s*\(.*\)|expose_php=Off|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^\(;\)*realpath_cache_size\s*=\s*\(.*\)|realpath_cache_size=\2|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^\(;\)*realpath_cache_ttl\s*=\s*\(.*\)|realpath_cache_ttl=3600|g" $PHP_INI_DIR/php.ini \
+  ; sed -i "s|^\(;\)*zlib.output_compression\s*=\s*\(.*\)|zlib.output_compression=On|g" $PHP_INI_DIR/php.ini \
+  ;
+
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+
+WORKDIR /var/www/html
+CMD ["php" "-a"]


### PR DESCRIPTION
- Force previous build to 8.0 images only
- Added 8.1 image builds
- Create 8.0 and 8.1 tags on Docker Hub instead of overwriting php:8 images